### PR TITLE
Create static_cast.cpp

### DIFF
--- a/C++/static_cast.cpp
+++ b/C++/static_cast.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <string>
+using namespace std;
+class demo {
+int a;
+public:
+demo(int a_i = 1)
+: a{a_i }
+{
+cout << "The conversion is called through this method" << endl;
+}
+operator string()
+{
+cout << "The casting conversion operation is:" << endl;
+return to_string(a);
+}
+};
+int main()
+{
+demo b(4);
+string s = b;
+b = 32;
+string s1 = static_cast<string>(b);
+b = static_cast<demo>(34);
+return 0;
+}


### PR DESCRIPTION
The C++ static_cast is defined as the operator which has to convert the variable from one data type into another data type mainly it transform into float data type the compiler only done this conversion in the static_cast because it constantly focus on the const types like const_cast, reinterpret_cast it also casting from one type into another type same like casting technique it uses both the implicit and explicit conversions the constructor which is used for applying only the compile-time so it can’t throw any exceptions and also if sometimes the casting is not done in any lines it will not compiled.